### PR TITLE
Fix `hide_symlinks` hyphen naming

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ pub struct Location {
     #[serde(default)]
     pub setuid:           bool,
     pub directory:        String,
-    #[serde(default)]
+    #[serde(rename = "hide-symlinks", default)]
     pub hide_symlinks:    Option<bool>,
     #[serde(default)]
     pub indexfile:        Option<String>,


### PR DESCRIPTION
Currently, the `hide-symlinks` config provided in example `webdav-server.toml` does not take effect, what takes effect is `hide_symlinks`.

This PR renames config `hide_symlinks` to `hide-symlinks` so as to fix such inconsistency.