### PR TITLE
Add `fs_quota`'s example to cargo toml

### DIFF
--- a/fs_quota/Cargo.toml
+++ b/fs_quota/Cargo.toml
@@ -28,3 +28,6 @@ cc = "1.0.66"
 [dependencies]
 libc = "0.2.82"
 log = "0.4.13"
+
+[[example]]
+name = "fs_quota"


### PR DESCRIPTION
This PR adds `examples/fs_quota.rs` to `fs_quota`'s cargo toml, so this example could be run by `cargo run --example fs_quota <args>`.