### PR TITLE
Add x auth

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,7 @@ pub enum AuthType {
     #[cfg(feature = "pam")]
     Pam,
     HtPasswd(String),
+    XAuth,
 }
 
 #[derive(FromStr, Debug, Clone, Copy)]
@@ -234,6 +235,9 @@ where D: Deserializer<'de> {
     #[cfg(feature = "pam")]
     if &s == "pam" {
         return Ok(Some(AuthType::Pam));
+    }
+    if &s == "x-authorization" {
+        return Ok(Some(AuthType::XAuth));
     }
     if s == "" {
         return Ok(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,6 @@ use std::process::exit;
 use std::sync::Arc;
 
 use clap::clap_app;
-use headers::{authorization::Basic, Authorization, HeaderMapExt};
 use http::status::StatusCode;
 use hyper::{
     self,
@@ -228,12 +227,11 @@ impl Server {
         };
 
         // Do authentication if needed.
-        let auth_hdr = req.headers().typed_get::<Authorization<Basic>>();
         let do_auth = match location.auth {
             Some(Auth::True) => true,
-            Some(Auth::Write) => !DavMethodSet::WEBDAV_RO.contains(method) || auth_hdr.is_some(),
+            Some(Auth::Write) => !DavMethodSet::WEBDAV_RO.contains(method),
             Some(Auth::False) => false,
-            Some(Auth::Opportunistic) | None => auth_hdr.is_some(),
+            Some(Auth::Opportunistic) | None => false,
         };
         let auth_user = if do_auth {
             let user = match self.auth.auth(&req, location, remote_ip).await {


### PR DESCRIPTION
Hi!
First of all, thank you for this project!

This PR adds authentication method using `x-authorization` header.
With this, you can a reverse proxy to the webdav-server (for example apache) which authenticate clients using for example kerberos. Once the authentication done, the reverse proxy forward http requests to the wedav-server adding the `x-authorization` header. In this mode, this header is trusted by the webdav-server and contains the authenticated username.

Side effects of the PR:
The original code always tries to get the authentication header, and add the possibility do to "opportunistic" authentication.
As at this point we don't know which header we may use, the code remove this opportunistic authentication. The authentication is mandatory or not.

