### PR TITLE
Return quota information based on query path

### DIFF
--- a/fs_quota/Cargo.toml
+++ b/fs_quota/Cargo.toml
@@ -28,3 +28,6 @@ cc = "1.0.66"
 [dependencies]
 libc = "0.2.82"
 log = "0.4.13"
+
+[[example]]
+name = "fs_quota"

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -70,8 +70,8 @@ impl DavFileSystem for RootFs {
     }
 
     // forward quota.
-    fn get_quota(&self) -> FsFuture<(u64, Option<u64>)> {
-        self.fs.get_quota()
+    fn get_quota<'a>(&'a self, path: &'a DavPath) -> FsFuture<(u64, Option<u64>)> {
+        self.fs.get_quota(path)
     }
 }
 


### PR DESCRIPTION
This PR is the implementation of https://github.com/miquels/webdav-handler-rs/pull/25.

It will append the queried path to `self.basedir`, so the quota query is based on the actual query path, instead of the root path.

Explanations from https://github.com/miquels/webdav-handler-rs/pull/25 :

> There are many cases when we use a folder like `/media` to export as webdav file root, but subfolders in `/media` are mounted with other filesystems:
> 
> ```
> /media -> rootfs
> /media/dirA -> external ext4 system
> /media/dirB -> external NTFS system
> ```
> 
> Currently, `get_quota` only collects quota information of root folder (the `/media`), even the client is querying quota information of path `/media/dirA` or `/media/dirB`.
> 
> When using clients like `RaiDrive` in Windows, it will report disk usage just like normal physical disks, and we expect it to show the correct disk usage of drive `/media/dirA` or `/media/dirB` (maybe some TBs large), but not the `/media` from rootfs `(maybe just tens of GBs).

