### PR TITLE
fix acl failure (#25) and pam auth (#26)

### DIFF
--- a/pam/src/pamclient.rs
+++ b/pam/src/pamclient.rs
@@ -157,6 +157,7 @@ struct PamAuthTask {
 impl PamAuthTask {
     // Start the server process. Then return a handle to send requests on.
     fn start(serversock: StdUnixStream) -> io::Result<mpsc::Sender<PamRequest1>> {
+        serversock.set_nonblocking(true)?; // so we can use it in tokio.
         let mut serversock = UnixStream::from_std(serversock)?;
 
         // create a request channel.

--- a/src/unixuser.rs
+++ b/src/unixuser.rs
@@ -91,10 +91,10 @@ impl User {
                 let groups = unsafe {
                     std::slice::from_raw_parts(buf.as_ptr() as *const libc::gid_t, ngroups as usize)
                 };
-                //
-                // Only supplementary or auxilary groups, filter out primary.
-                //
-                groups_vec.extend(groups.iter().map(|&g| g as u32).filter(|&g| g != user.gid));
+                // Keep it as is, not filtering.
+                // Some systems requires the GID to be in the list, for some mechanisms (eg. ACL) to work.
+                // See also #25.
+                groups_vec.extend(groups.iter().map(|&g| g as u32));
                 user.groups = groups_vec;
             }
         }


### PR DESCRIPTION
- fix: maintain consistency for user groups with system (#25)  
   At least TrueNAS's NFSv4 ACL impl for ZFS requires such a fix.
- fix(pam): unix socket got stuck (#26)